### PR TITLE
Changing the version of the maven-compiler-plugin

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -111,7 +111,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.13.0</version>
         <configuration>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>


### PR DESCRIPTION
I replaced the following line with -> to successfully compile ambari-server ->
Before:
maven-compiler-plugin
<3.2>
After:
maven-compiler-plugin
<3.13.0>