### PR TITLE
Fixing maven-compiler-plugin incompatibility

### DIFF
--- a/ambari-server/pom.xml
+++ b/ambari-server/pom.xml
@@ -111,7 +111,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.13.0</version>
         <configuration>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>


### PR DESCRIPTION
Replace the main component dependency for running ambari-server

I changed the version of the maven-compiler-plugin dependency from 3.2 to 3.13.0 in my local branch to build ambari-server correctly. 

Closing the issue:  Close #12 

